### PR TITLE
Update Pic.cc

### DIFF
--- a/Accelerated C++/chapter15/Pic.cc
+++ b/Accelerated C++/chapter15/Pic.cc
@@ -76,7 +76,7 @@ void HCat_Pic::display(ostream& os, ht_sz row, bool do_pad) const {
     left_row = (row < v_pad) ? left->height() : row - v_pad;
   }
 
-  left->display(os, left_row, do_pad || row < right->height());
+  left->display(os, left_row, do_pad || right_row < right->height());
   right->display(os, right_row, do_pad);
 }
 


### PR DESCRIPTION
>15-5, HCat::Display() pads incorrectly.
If an HCat is created from two String_Pic Pictures, the padding is incorrect.  It doesn't pad the left picture for the last line of the right picture.

Submitted fix.